### PR TITLE
Segmentation Fault

### DIFF
--- a/sw_src/SNN_sim/tinyODIN.c
+++ b/sw_src/SNN_sim/tinyODIN.c
@@ -155,8 +155,8 @@ void print_accuracy(int *correct_guesses){
   printf("Accuracy: %.2f%%\n", accuracy);
 }
 
-int main() {
   int test_images[10000][256] = {{0}};
+int main() {
   int test_labels[DATASET_SIZE] = {0};
   int weights[IL_neurons][OL_neurons] = {{0}};
 


### PR DESCRIPTION
The large array **test_images** has been moved from a local scope(stack) in the **main** function to a global scope(data segment). This change was made to prevent segmentation faults caused by stack overflow. 
